### PR TITLE
su command needs `-c` argument

### DIFF
--- a/ipf/etc/ipf/init.d/ipf-WORKFLOW
+++ b/ipf/etc/ipf/init.d/ipf-WORKFLOW
@@ -61,7 +61,7 @@ stop() {
         pkill -9 -P $PID
         RETVAL=$?
         echo
-	[ $RETVAL -eq 0 ] && su $IPF_USER rm -f $PID_FILE
+	[ $RETVAL -eq 0 ] && su $IPF_USER -c "rm -f $PID_FILE"
         return $RETVAL
 }
 


### PR DESCRIPTION
This fixes one of a few snags we (Jetstream2) hit when setting up IPF. [Full notes from our setup experience here.](https://gitlab.com/jetstream-cloud/project-mgt/-/issues/141)

The `stop()` case of each init script passes a command to `su` (instead of starting an interactive shell), but without the needed `-c` argument, it breaks and it fails to remove the PID file. This PR adds the argument, after which the service stops and restarts successfully.