### PR TITLE
Implement lmod cache in extmodules workflow

### DIFF
--- a/ipf/configure/configure_workflows.py
+++ b/ipf/configure/configure_workflows.py
@@ -94,6 +94,8 @@ def parseargs():
                         help='Interval in hours for the ExtModules workflow to wait before rerunning')
     parser.add_argument('--services_interval', \
                         help='Interval in hours for the AbstractServices workflow to wait before rerunning')
+    parser.add_argument('--lmod_cache_file', \
+                        help='full path to lmod cache file to use in ExtModules workflow')
     parser.add_argument('--modules_exclude', \
                         help='comma delimited list of names of modules to exclude.')
     parser.add_argument('--modules_recurse', action='store_true', \
@@ -323,6 +325,12 @@ def setExtModulesParams(extmodules_json,args):
                 else:
                     step_json["params"]={}
                     step_json["params"]["exclude"] = args.modules_exclude
+            if args.lmod_cache_file is not None:
+                if "params" in step_json:
+                    step_json["params"]["lmod_cache_file"] = args.lmod_cache_file
+                else:
+                    step_json["params"]={}
+                    step_json["params"]["lmod_cache_file"] = args.lmod_cache_file
             return
     raise Exception("didn't find an ExtendedModApplicationsStep to modify")
 

--- a/ipf/glue2/modules.py
+++ b/ipf/glue2/modules.py
@@ -334,7 +334,7 @@ class ExtendedModApplicationsStep(application.ApplicationsStep):
             else:
                 for path in module_paths:
                     self._traversePaths(path, path, module_paths, apps)
-            return apps
+        return apps
 
     def _traversePaths(self, path, module_path, module_paths, apps):
         try:


### PR DESCRIPTION
Adds parameter "lmod_cache_file" to the extmodules workflow.  When specified, the workflow only looks at module files in the spiderT table from the specified lmod cache, and does not add any modules found in the hiddenT table from the specified lmod cache.