### PR TITLE
CTT-661/unique dev version string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,216 @@
+# Custom
 *.pyc
 *~
 .DS_Store
-build/
-dist/
-eggs/
-*.egg*
 *.swp
 *.old
-venv
 _version.py
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 .DS_Store
 build/
 dist/
-ipf.egg-info/
+eggs/
+*.egg*
 *.swp
-_version.py
 *.old
+venv
+_version.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+SHELL=/bin/bash
+DIRNAME := $(shell basename $$(pwd))
+SITEPKGS := $(shell python3 -c 'import site; print(site.getsitepackages()[0])')
+
+help:
+	@echo
+	@echo "Synopsis: make [ build clean vars version ]"
+	@echo
+
+vars:
+	@echo "DIRNAME: '${DIRNAME}'"
+	@echo "SITEPKGS: '${SITEPKGS}'"
+
+version: pkg_deps
+	python3 -m setuptools_scm
+
+build: pkg_deps
+	python3 -m build
+
+pkg_deps: ${SITEPKGS}/build ${SITEPKGS}/setuptools_scm
+
+${SITEPKGS}/build:
+	python3 -m pip install --upgrade build
+
+${SITEPKGS}/setuptools_scm:
+	python3 -m pip install --upgrade setuptools-scm
+
+clean:
+	rm -rf dist/
+	rm -rf ipf.egg-info/

--- a/ipf/build_helper.py
+++ b/ipf/build_helper.py
@@ -1,0 +1,23 @@
+from setuptools_scm.version import guess_next_version
+import time
+def mk_version( version ):
+    # setuptools_scm template options
+    # see also https://github.com/pypa/setuptools-scm/blob/main/src/setuptools_scm/version.py especially "def meta( ... )"
+    # '{branch}',
+    # '{dirty}',
+    # '{distance}',
+    # '{node}',
+    # '{node_date}',
+    # '{time}',
+    # SPEACIAL NAMES
+    # '{guessed}', #from version.py:format_next_version(...)
+
+    final = 'unknown'
+    if version.exact :
+        final = version.format_with( '{tag}' )
+    else :
+        # unix timestamp as dev qualifier, ensures it's always unique
+        # to comply with test.pypi.org requirement to NEVER re-use a version
+        fmt_str = '{guessed}.dev' + str(int(time.time()))
+        final = version.format_next_version( guess_next_version, fmt_str )
+    return final

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [ "setuptools >= 80", "setuptools-scm >= 8.3", ]
-# build-backend = "setuptools.build_meta"
 build-backend = "setuptools.build_meta:__legacy__"
-# __legacy__ enables acces to function in the local package
+# __legacy__ enables access to function in the local package
 # see also https://setuptools-git-versioning.readthedocs.io/en/stable/options/version_callback.html
 
 [project]
@@ -39,23 +38,10 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/access-ci-org/ipf"
 
-# [project.scripts]
-# ipf_workflow = "ipf.run_workflow:main"
-# ipf_configure = "ipf.configure.configure_workflows:configure"
-# mk_version = "ipf.build_helper:mk_version"
-
-# [project.entry-points."setuptools_scm.version_scheme"]
-# # version = "ipf.build_helper:mk_version"
-# # version = "build_helper:mk_version"
-# mk_version = "ipf.build_helper:mk_version"
-
 [tool.setuptools.dynamic]
 readme = { file = [ "README.md" ] }
 
 [tool.setuptools_scm]
 version_file = "ipf/_version.py"
-# version_scheme = "guess-next-dev"  # this is the default
 version_scheme = "ipf.build_helper:mk_version"
-# version_scheme = "build_helper:mk_version"
-# version_scheme = "mk_version"
 local_scheme = "no-local-version"  # local version component not allowed on pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
-requires = [ "setuptools>=61", "setuptools-scm", ]
-build-backend = "setuptools.build_meta"
+requires = [ "setuptools >= 80", "setuptools-scm >= 8.3", ]
+# build-backend = "setuptools.build_meta"
+build-backend = "setuptools.build_meta:__legacy__"
+# __legacy__ enables acces to function in the local package
+# see also https://setuptools-git-versioning.readthedocs.io/en/stable/options/version_callback.html
 
 [project]
 name = "ipf"
@@ -36,15 +39,23 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/access-ci-org/ipf"
 
-[project.scripts]
-ipf_workflow = "ipf.run_workflow:main"
-ipf_configure = "ipf.configure.configure_workflows:configure"
+# [project.scripts]
+# ipf_workflow = "ipf.run_workflow:main"
+# ipf_configure = "ipf.configure.configure_workflows:configure"
+# mk_version = "ipf.build_helper:mk_version"
+
+# [project.entry-points."setuptools_scm.version_scheme"]
+# # version = "ipf.build_helper:mk_version"
+# # version = "build_helper:mk_version"
+# mk_version = "ipf.build_helper:mk_version"
 
 [tool.setuptools.dynamic]
-# version = { attr = "ipf.__version__" }
 readme = { file = [ "README.md" ] }
 
 [tool.setuptools_scm]
 version_file = "ipf/_version.py"
-version_scheme = "guess-next-dev"  # this is the default
+# version_scheme = "guess-next-dev"  # this is the default
+version_scheme = "ipf.build_helper:mk_version"
+# version_scheme = "build_helper:mk_version"
+# version_scheme = "mk_version"
 local_scheme = "no-local-version"  # local version component not allowed on pypi


### PR DESCRIPTION
Make setuptools_scm guess next version use timestamp for dev version publishing to test.pypi so they are always unique. Ensures even after rebase and squash-n-merge that publishing will succeed. Prevents confusion so a merge doesn't have a red check indicating something failed (even though it's just publishing to test.pypi).